### PR TITLE
Extend astroHTML.JSX to allow for _hyperscript attributes

### DIFF
--- a/hyperscript-attributes.d.ts
+++ b/hyperscript-attributes.d.ts
@@ -1,0 +1,5 @@
+declare namespace astroHTML.JSX {
+  interface DOMAttributes {
+    _?: string;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "astro/tsconfigs/strictest"
+  "extends": "astro/tsconfigs/strictest",
+  "include": ["src", "hyperscript-attributes.d.ts"] // Include your declaration file here
 }


### PR DESCRIPTION
Solves this error below.

![image](https://github.com/tony-sull/todomvc-astro-htmx/assets/62069101/acdaf2c5-5e3d-407e-a5fd-4c1f4ecef6cb)
